### PR TITLE
Various Changes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 import bpy
-
 from .operators.polyhedral_splines import PolyhedralSplines
 from .operators.highlighter import Highlighter
 from .operators.main_ui import MainUI
 from .operators.ui_helper import ToggleFaces, ToggleSurfPatchCollection
 from .operators.ui_color import COLOR_OT_TemplateOperator
 from .operators.moments import Moments
+from .operators.subdivide_mesh import SubdivideMesh
 
 bl_info = {
     "name": "polyhedral_splines",
@@ -22,7 +22,8 @@ classes = (
     ToggleSurfPatchCollection,
     MainUI,
     COLOR_OT_TemplateOperator,
-    Moments
+    Moments,
+    SubdivideMesh
 )
 
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ from .operators.highlighter import Highlighter
 from .operators.main_ui import MainUI
 from .operators.ui_helper import ToggleFaces, ToggleSurfPatchCollection
 from .operators.ui_color import COLOR_OT_TemplateOperator
+from .operators.moments import Moments
 
 bl_info = {
     "name": "polyhedral_splines",
@@ -20,7 +21,8 @@ classes = (
     ToggleFaces,
     ToggleSurfPatchCollection,
     MainUI,
-    COLOR_OT_TemplateOperator
+    COLOR_OT_TemplateOperator,
+    Moments
 )
 
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/operators/extraordinary_patch_constructor.py
+++ b/operators/extraordinary_patch_constructor.py
@@ -59,7 +59,7 @@ class ExtraordinaryPatchConstructor(PatchConstructor):
         return nb_verts
 
     @classmethod
-    def get_patch(cls, vert, isBspline = True) -> list:
+    def get_patch(cls, vert, isBspline = True) -> BsplinePatch | BezierPatch:
         deg_u = 3
         deg_v = 3
         order_u = deg_u + 1
@@ -77,6 +77,7 @@ class ExtraordinaryPatchConstructor(PatchConstructor):
         # The number of patches = # of rows / # of coef per patch
         num_of_coef_per_patch = (deg_u + 1) * (deg_v + 1)
         num_of_patches = len(bspline_coefs) / num_of_coef_per_patch
+        
         if(isBspline):
             return BsplinePatch(
                 order_u=order_u,

--- a/operators/main_ui.py
+++ b/operators/main_ui.py
@@ -2,6 +2,7 @@ from .highlighter import Highlighter
 from .polyhedral_splines import PolyhedralSplines
 from .ui_color import COLOR_OT_TemplateOperator
 from .moments import Moments
+from .ui_helper import ToggleFaces, ToggleSurfPatchCollection
 import bpy
 
 
@@ -23,6 +24,8 @@ class MainUI(bpy.types.Panel):
         layout.operator(operator=Highlighter.bl_idname, text="Inspect Mesh")
         layout.operator(operator=PolyhedralSplines.bl_idname, text="Generate Bspline Patches")
         layout.operator(operator=COLOR_OT_TemplateOperator.bl_idname, text="Patch Color")
+        layout.operator(operator=ToggleFaces.bl_idname, text="Toggle Mesh Faces")
+        layout.operator(operator=ToggleSurfPatchCollection.bl_idname, text="Toggle SurfPatch Collection")
 
         layout.label(text="Volume: " + str(Moments.Volume))
         layout.label(text="Center of Mass: " + str(Moments.CoM))

--- a/operators/main_ui.py
+++ b/operators/main_ui.py
@@ -26,7 +26,7 @@ class MainUI(bpy.types.Panel):
         layout.operator(operator=COLOR_OT_TemplateOperator.bl_idname, text="Patch Color")
         layout.operator(operator=ToggleFaces.bl_idname, text="Toggle Mesh Faces")
         layout.operator(operator=ToggleSurfPatchCollection.bl_idname, text="Toggle SurfPatch Collection")
-        #layout.operator(operator=Moments.bl_idname, text="Recompute Moments")
+        layout.operator(operator=Moments.bl_idname, text="Calculate Moments")
 
         layout.label(text="Volume: " + str(Moments.Volume))
         layout.label(text="Center of Mass: " + str(Moments.CoM))

--- a/operators/main_ui.py
+++ b/operators/main_ui.py
@@ -1,3 +1,4 @@
+from .subdivide_mesh import SubdivideMesh
 from .highlighter import Highlighter
 from .polyhedral_splines import PolyhedralSplines
 from .ui_color import COLOR_OT_TemplateOperator
@@ -21,16 +22,25 @@ class MainUI(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator(operator=Highlighter.bl_idname, text="Inspect Mesh")
-        layout.operator(operator=PolyhedralSplines.bl_idname, text="Generate Bspline Patches")
-        layout.operator(operator=COLOR_OT_TemplateOperator.bl_idname, text="Patch Color")
-        layout.operator(operator=ToggleFaces.bl_idname, text="Toggle Mesh Faces")
-        layout.operator(operator=ToggleSurfPatchCollection.bl_idname, text="Toggle SurfPatch Collection")
-        layout.operator(operator=Moments.bl_idname, text="Calculate Moments")
 
-        layout.label(text="Volume: " + str(Moments.Volume))
-        layout.label(text="Center of Mass: " + str(Moments.CoM))
-        layout.label(text="Inertia Tensors: ")
-        layout.label(text="     X: " + str(Moments.InertiaTens[0]))
-        layout.label(text="     Y: " + str(Moments.InertiaTens[1]))
-        layout.label(text="     Z: " + str(Moments.InertiaTens[2]))
+        calculationBox = layout.box()
+        calculationBox.label(text="Calculations")
+        calculationBox.operator(operator=PolyhedralSplines.bl_idname, text="Generate Bspline Patches")
+        calculationBox.operator(operator=SubdivideMesh.bl_idname, text="Subdivide Mesh")
+        calculationBox.operator(operator=Moments.bl_idname, text="Calculate Moments")
+
+        viewBox = layout.box()
+        viewBox.label(text="View")
+        viewBox.operator(operator=Highlighter.bl_idname, text="Inspect Mesh")
+        viewBox.operator(operator=COLOR_OT_TemplateOperator.bl_idname, text="Patch Color")
+        viewBox.operator(operator=ToggleFaces.bl_idname, text="Toggle Mesh Faces")
+        viewBox.operator(operator=ToggleSurfPatchCollection.bl_idname, text="Toggle SurfPatch Collection")
+
+        valuesBox = layout.box()
+        valuesBox.label(text="Values")
+        valuesBox.label(text="Volume: " + str(Moments.Volume))
+        valuesBox.label(text="Center of Mass: " + str(Moments.CoM))
+        valuesBox.label(text="Inertia Tensors: ")
+        valuesBox.label(text="     X: " + str(Moments.InertiaTens[0]))
+        valuesBox.label(text="     Y: " + str(Moments.InertiaTens[1]))
+        valuesBox.label(text="     Z: " + str(Moments.InertiaTens[2]))

--- a/operators/main_ui.py
+++ b/operators/main_ui.py
@@ -26,6 +26,7 @@ class MainUI(bpy.types.Panel):
         layout.operator(operator=COLOR_OT_TemplateOperator.bl_idname, text="Patch Color")
         layout.operator(operator=ToggleFaces.bl_idname, text="Toggle Mesh Faces")
         layout.operator(operator=ToggleSurfPatchCollection.bl_idname, text="Toggle SurfPatch Collection")
+        #layout.operator(operator=Moments.bl_idname, text="Recompute Moments")
 
         layout.label(text="Volume: " + str(Moments.Volume))
         layout.label(text="Center of Mass: " + str(Moments.CoM))

--- a/operators/moments.py
+++ b/operators/moments.py
@@ -35,28 +35,19 @@ class Moments(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        """
         obj = context.active_object
-        if obj == None:
-            print("No active object.")
-            return False
-        else:
+        if obj.name in Moments.ControlMeshNames:
             return True
-        """
+        return False
 
-        return True
-
-
+    # TODO: variable size based on madnitude of vector                                                                                                
+    # calculate rotation from vector
     def execute(self, context):
-        if Moments.CurrentSelection is None:
-            Moments.CurrentSelection = context.view_layers[0].objects.active
-            if Moments.CurrentSelection.name in Moments.ControlMeshNames:
-                Moments.cleanupObjects()
-                Moments.recalculateMoments(context, Moments.CurrentSelection.name)
-                Moments.createCenterOfMass(context, Moments.CoM)                            #display center of mass as vertex and small sphere for visibility
-                                                                                            # TODO: variable size based on madnitude of vector
-                                                                                            #      calculate rotation from vector
-                Moments.createArrows(context)
+        Moments.CurrentSelection = context.view_layer.objects.active
+        Moments.cleanupObjects()
+        Moments.recalculateMoments(context, Moments.CurrentSelection.name)
+        Moments.createCenterOfMass(context, Moments.CoM)
+        Moments.createArrows(context)
             
         return {'FINISHED'}
 
@@ -276,11 +267,9 @@ class Moments(bpy.types.Operator):
 
 @persistent
 def objectHandler(context):
-    obj = bpy.context.active_object
+    selected = bpy.context.selected_objects
 
-    if obj.name in Moments.ControlMeshNames:
-        Moments.execute(None, context)
-    else:
+    if Moments.CurrentSelection not in selected:
         Moments.cleanupObjects()
         Moments.CurrentSelection = None
 

--- a/operators/moments.py
+++ b/operators/moments.py
@@ -17,6 +17,7 @@ from bpy.app.handlers import persistent
 class Moments(bpy.types.Operator):
     bl_label = "Calculate Moments"
     bl_idname = "object.moments"
+    bl_description = "Calculates moment inertia values for the active object. Values are displayed on the bottom of the panel"
     
     Volume = 0                       # display volume in UI
     CoM = [[], [], []]                        # put point at center of mass

--- a/operators/moments.py
+++ b/operators/moments.py
@@ -51,6 +51,13 @@ class Moments(bpy.types.Operator):
             
         return {'FINISHED'}
 
+    def executeBM(context, bm, controlMeshName):
+        Moments.CurrentSelection = context.view_layer.objects[controlMeshName]
+        Moments.cleanupObjects()
+        Moments.calculateMoments(context, bm, Moments.CurrentSelection.name)
+        Moments.createCenterOfMass(context, Moments.CoM)
+        Moments.createArrows(context)
+
     def cleanupObjects():
         #Delete arrow objects
         for arrow in Moments.ArrowObjs:

--- a/operators/moments.py
+++ b/operators/moments.py
@@ -47,18 +47,12 @@ class Moments(bpy.types.Operator):
     def execute(self, context):
         Moments.CurrentSelection = context.view_layer.objects.active
         Moments.cleanupObjects()
-        Moments.recalculateMoments(context, Moments.CurrentSelection.name)
-        Moments.createCenterOfMass(context, Moments.CoM)
-        Moments.createArrows(context)
-            
-        return {'FINISHED'}
 
-    def executeBM(context, bm, controlMeshName):
-        Moments.CurrentSelection = context.view_layer.objects[controlMeshName]
-        Moments.cleanupObjects()
-        Moments.calculateMoments(context, bm, Moments.CurrentSelection.name)
+        Moments.calculateMoments(context, Moments.CurrentSelection.name)
         Moments.createCenterOfMass(context, Moments.CoM)
         Moments.createArrows(context)
+
+        return {'FINISHED'}
 
     def cleanupObjects():
         #Delete arrow objects
@@ -78,13 +72,10 @@ class Moments(bpy.types.Operator):
         Moments.createArrow(context, np.linalg.norm(Moments.InertiaTens[1])/5, (0, 1, 0, 1), Moments.InertiaTens[1])     #context, location, size, color(RGBA), rotation
         Moments.createArrow(context, np.linalg.norm(Moments.InertiaTens[2])/5, (0, 0, 1, 1), Moments.InertiaTens[2])     #context, location, size, color(RGBA), rotation
 
-    def recalculateMoments(context, controlMeshName):
+    def calculateMoments(context, controlMeshName):
         mesh = Moments.CurrentSelection.data
         bm = bmesh.new()
         bm.from_mesh(mesh)
-        Moments.calculateMoments(context, bm, controlMeshName)
-
-    def calculateMoments(context, bm, controlMeshName):
 
         if controlMeshName not in Moments.ControlMeshNames:
             Moments.ControlMeshNames.append(controlMeshName)

--- a/operators/moments.py
+++ b/operators/moments.py
@@ -36,7 +36,9 @@ class Moments(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        if obj.name in Moments.ControlMeshNames:
+        selected = context.selected_objects
+
+        if obj in selected and obj.name in Moments.ControlMeshNames:
             return True
         return False
 
@@ -272,6 +274,7 @@ class Moments(bpy.types.Operator):
         Moments.ArrowObjs.append(obj)
         
 
+#Remove arrows when deselecting object
 @persistent
 def objectHandler(context):
     selected = bpy.context.selected_objects
@@ -283,3 +286,16 @@ def objectHandler(context):
     return None
 
 bpy.app.handlers.depsgraph_update_post.append(objectHandler)
+
+#Clean up member variables on scene change
+@persistent
+def sceneLoadHandler(context):
+    Moments.Volume = 0
+    Moments.CoM = [[], [], []]
+    Moments.InertiaTens = [[[],[],[]],[[],[],[]],[[],[],[]]]
+    Moments.CurrentSelection = None
+    Moments.ControlMeshNames = []
+    Moments.CenterOfMassObj = None
+    Moments.ArrowObjs = []
+
+bpy.app.handlers.load_post.append(sceneLoadHandler)

--- a/operators/patch_helper.py
+++ b/operators/patch_helper.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+
+from .patch import BezierPatch, BsplinePatch
+from .extraordinary_patch_constructor import ExtraordinaryPatchConstructor
+from .n_gon_patch_constructor import NGonPatchConstructor
+from .polar_patch_constructor import PolarPatchConstructor
+from .reg_patch_constructor import RegPatchConstructor
+from .t0_patch_constructor import T0PatchConstructor
+from .t1_patch_constructor import T1PatchConstructor
+from .t2_patch_constructor import T2PatchConstructor
+from .two_triangles_two_quads_patch_constructor import TwoTrianglesTwoQuadsPatchConstructor
+
+@dataclass
+class PatchWrapper:
+    patch: BsplinePatch | BezierPatch = None
+    isBSpline = False
+    source = None   #The source vert/face the patch is based on
+    neighbors = []
+
+    def __init__(self, patch, isBSpline, source, neighbors):
+        self.patch = patch
+        self.isBSpline = isBSpline
+        self.source = source
+        self.neighbors = neighbors
+
+class PatchHelper:
+    # The algorithm using vert as center
+    vert_based_patch_constructors: list = [
+        RegPatchConstructor,
+        ExtraordinaryPatchConstructor,
+        PolarPatchConstructor,
+        TwoTrianglesTwoQuadsPatchConstructor
+    ]
+    # The algorithm using face as center
+    face_based_patch_constructors: list = [
+        T0PatchConstructor,
+        T1PatchConstructor,
+        T2PatchConstructor,
+        NGonPatchConstructor
+    ]
+
+    @staticmethod
+    def getPatches(bMesh, isBSpline = True) -> list[PatchWrapper]:
+        patchWrappers = []
+
+        vertPatches = PatchHelper.getVertPatches(bMesh, isBSpline)
+        facePatches = PatchHelper.getFacePatches(bMesh, isBSpline)
+
+        patchWrappers.extend(vertPatches)
+        patchWrappers.extend(facePatches)
+
+        return patchWrappers
+
+    @staticmethod 
+    def getVertPatches(bMesh, isBSpline = True) -> list[PatchWrapper]:
+        bsplinePatches = []
+        # Iterate through each vert of the mesh
+        for v in bMesh.verts:
+            # Iterate throgh different type of patch constructors
+            for pc in PatchHelper.vert_based_patch_constructors:
+                if pc.is_same_type(v):
+                    patch: BsplinePatch = pc.get_patch(v, isBSpline)
+                    neighborVerts: list = pc.get_neighbor_verts(v)
+                    patchWrapper = PatchWrapper(patch, isBSpline, v, neighborVerts)
+                    bsplinePatches.append(patchWrapper)
+        return bsplinePatches
+
+    @staticmethod
+    def getFacePatches(bMesh, isBSpline = True) -> list[PatchWrapper]:
+        bsplinePatches = []
+        # Iterate through each face of the mesh
+        for f in bMesh.faces:
+            # Iterate throgh different type of patch constructors
+            for pc in PatchHelper.face_based_patch_constructors:
+                if pc.is_same_type(f):
+                    patch: BsplinePatch = pc.get_patch(f, isBSpline)
+                    neighborVerts: list = pc.get_neighbor_verts(f)
+                    patchWrapper = PatchWrapper(patch, isBSpline, f, neighborVerts)
+                    bsplinePatches.append(patchWrapper)
+        return bsplinePatches

--- a/operators/polyhedral_splines.py
+++ b/operators/polyhedral_splines.py
@@ -94,6 +94,8 @@ class PolyhedralSplines(bpy.types.Operator):
                     nb_verts = pc.get_neighbor_verts(v)
                     PatchTracker.register_multiple_patches(v, nb_verts, patch_names)
                     print("Generate patch obj time usage (sec): ", time.process_time() - start)
+                    for patch_name in patch_names:
+                        bpy.context.scene.objects[patch_name].parent = obj
 
         # Iterate through each face of the mesh
         for f in bm.faces:
@@ -103,6 +105,8 @@ class PolyhedralSplines(bpy.types.Operator):
                     patch_names = PatchOperator.generate_multiple_patch_obj(bspline_patches)
                     nb_verts = pc.get_neighbor_verts(f)
                     PatchTracker.register_multiple_patches(f, nb_verts, patch_names)
+                    for patch_name in patch_names:
+                        bpy.context.scene.objects[patch_name].parent = obj
 
         Moments.calculateMoments(self=self, context = context, bm=bm)
         # Finish up, write the bmesh back to the mesh

--- a/operators/polyhedral_splines.py
+++ b/operators/polyhedral_splines.py
@@ -26,6 +26,7 @@ import time
 class PolyhedralSplines(bpy.types.Operator):
     bl_label = "Interactive Modeling"
     bl_idname = "object.polyhedral_splines"
+    bl_description = "Generates polyhedral spline mesh. Some mesh configurations are not supported, subdivide the mesh beforehand if this is the case"
 
     # The algorithm using face as center
     face_based_patch_constructors: list = [
@@ -87,7 +88,7 @@ class PolyhedralSplines(bpy.types.Operator):
 
         obj.select_set(True)
         bpy.context.view_layer.objects.active = obj
-        Moments.executeBM(context, bm, obj.name)
+        Moments.execute(self, context)
         # Finish up, write the bmesh back to the mesh
         if control_mesh.is_editmode:
             bmesh.update_edit_mesh(control_mesh)

--- a/operators/polyhedral_splines.py
+++ b/operators/polyhedral_splines.py
@@ -65,7 +65,13 @@ class PolyhedralSplines(bpy.types.Operator):
         else:
             return True
         """
-        return True
+
+        obj = context.active_object
+        selected = context.selected_objects
+
+        if obj in selected and obj.mode == "OBJECT" and obj.type == "MESH":
+            return True
+        return False
 
     def execute(self, context):
         self.__init_patch_obj__(context)
@@ -95,7 +101,9 @@ class PolyhedralSplines(bpy.types.Operator):
 
             print("Generate patch obj time usage (sec): ", time.process_time() - start)
 
-        Moments.calculateMoments(context, bm, obj.name)
+        obj.select_set(True)
+        bpy.context.view_layer.objects.active = obj
+        Moments.executeBM(context, bm, obj.name)
         # Finish up, write the bmesh back to the mesh
         if control_mesh.is_editmode:
             bmesh.update_edit_mesh(control_mesh)

--- a/operators/polyhedral_splines.py
+++ b/operators/polyhedral_splines.py
@@ -50,22 +50,6 @@ class PolyhedralSplines(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        """
-        Make the addon only can be found when object is active
-        and it is a mesh in edit mode.
-        """
-        """
-        obj = context.active_object
-        if obj == None:
-            print("No active object.")
-            return False
-        elif obj.mode != 'EDIT' or obj.type != 'MESH':
-            print("Not in edit mode or the object is not mesh.")
-            return False
-        else:
-            return True
-        """
-
         obj = context.active_object
         selected = context.selected_objects
 

--- a/operators/subdivide_mesh.py
+++ b/operators/subdivide_mesh.py
@@ -1,0 +1,27 @@
+import bpy
+
+class SubdivideMesh(bpy.types.Operator):
+    bl_label = "Subdivide Mesh"
+    bl_idname = "object.subdivide_mesh"
+    bl_description = "Applies 1 iteration of Catmull-Clark subdivision. Use if mesh is not fully supported by polyhedral spline generation"
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        selected = context.selected_objects
+
+        if obj in selected and obj.mode == "OBJECT" and obj.type == "MESH":
+            return True
+        return False
+
+    def execute(self, context):
+        obj = context.active_object
+
+        modifierName = "Subdivision"
+        subdivMod = obj.modifiers.new(modifierName, "SUBSURF")
+        subdivMod.levels = 1
+        subdivMod.subdivision_type = "CATMULL_CLARK"
+
+        bpy.ops.object.modifier_apply(modifier=modifierName)
+        
+        return {'FINISHED'}

--- a/operators/ui_helper.py
+++ b/operators/ui_helper.py
@@ -25,8 +25,8 @@ class ToggleFaces(bpy.types.Operator):
                         break
         return {'FINISHED'}
 
-    def menu_func(self, context):
-        self.layout.operator(ToggleFaces.bl_idname)
+    #def menu_func(self, context):
+    #    self.layout.operator(ToggleFaces.bl_idname)
 
     #bpy.types.VIEW3D_MT_view.append(menu_func)
 
@@ -46,7 +46,7 @@ class ToggleSurfPatchCollection(bpy.types.Operator):
                         break
         return {'FINISHED'}
 
-    def menu_func(self, context):
-        self.layout.operator(ToggleSurfPatchCollection.bl_idname)
+    #def menu_func(self, context):
+    #    self.layout.operator(ToggleSurfPatchCollection.bl_idname)
 
     #bpy.types.VIEW3D_MT_view.append(menu_func)

--- a/operators/ui_helper.py
+++ b/operators/ui_helper.py
@@ -28,7 +28,7 @@ class ToggleFaces(bpy.types.Operator):
     def menu_func(self, context):
         self.layout.operator(ToggleFaces.bl_idname)
 
-    bpy.types.VIEW3D_MT_view.append(menu_func)
+    #bpy.types.VIEW3D_MT_view.append(menu_func)
 
 
 class ToggleSurfPatchCollection(bpy.types.Operator):
@@ -49,4 +49,4 @@ class ToggleSurfPatchCollection(bpy.types.Operator):
     def menu_func(self, context):
         self.layout.operator(ToggleSurfPatchCollection.bl_idname)
 
-    bpy.types.VIEW3D_MT_view.append(menu_func)
+    #bpy.types.VIEW3D_MT_view.append(menu_func)


### PR DESCRIPTION
- Moved the "Toggle Mesh Faces" and "Toggle Patch Collection" buttons from the view dropdown on the top toolbar to the plugin's panel.
- Made patch generation and manipulation work properly in Object mode. The control object is parented to the patch objects.
- Added a PatchHelper class to remove redundant code.
- Restructured Moment calculation. Moment inertia is calculated and shown when the polyhedron is generated. The arrows are hidden when the object is deselected. It can be recalculated and shown again when the "Calculate Moments" button is clicked.
- Added a button to apply 1 step of Catmull-Clark subdivision to the active mesh. This is for meshes that aren't fully supported by the patch generations.
- Added descriptions for the buttons on the plugin panel.
