### PR TITLE
Minor Patch: changed halfedge get_verts_repeat_n_times number of repeat times to 1

### DIFF
--- a/operators/two_triangles_two_quads_patch_constructor.py
+++ b/operators/two_triangles_two_quads_patch_constructor.py
@@ -78,7 +78,7 @@ class TwoTrianglesTwoQuadsPatchConstructor(PatchConstructor):
 
         commands = [4, 1, 4, 1, 4, 1, 4, 3, 1, 1, 4, 4, 3, 1, 4, 1, 4, 3, 1, 1, 4]
         get_vert_order = [4, 5, 2, 1, 0, 3, 6, 7, 8]
-        nb_verts = Halfedge.get_verts_repeat_n_times(halfedge, commands, 4, get_vert_order, 9)
+        nb_verts = Halfedge.get_verts_repeat_n_times(halfedge, commands, 1, get_vert_order, 9)
 
         return nb_verts
 


### PR DESCRIPTION
The TwoTrianglesTwoQuadsPatchConstructor's get_neighbor_verts call to get_verts_repeat_n_times has a repeat parameter of 4, resulting in 36 vertices collected when only 9 are needed. Changed repeat from 4 to 1 accordingly.